### PR TITLE
reset diff state + clock_rate timing

### DIFF
--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -54,7 +54,7 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
     cudaMemcpyFromSymbol(&host_iters, iters, sizeof(host_iters), 0, cudaMemcpyDeviceToHost);
 
     printf("best difficulty %u in %lld iters\n", host_gbd, host_iters);
-    cudaMemcpy(out, &d_out, 32, cudaMemcpyDeviceToHost);
+    cudaMemcpy(out, d_out, 32, cudaMemcpyDeviceToHost);
 
     // Retrieve the results back to the host
     cudaMemcpyFromSymbol(out, global_best_nonce, sizeof(global_best_nonce), 0, cudaMemcpyDeviceToHost);

--- a/drillx/kernels/utils.cu
+++ b/drillx/kernels/utils.cu
@@ -34,7 +34,7 @@ extern "C" void gpu_init()
     block_size = (max_threads_per_mp / gcd(max_threads_per_mp, number_threads));
     number_threads = 256; // / block_size;
     number_blocks = block_size * number_multi_processors;
-    clock_rate = (unsigned long long)device_prop.clockRate;
+    clock_rate = 1800000;
 }
 
 __device__ uint64_t saturating_add(uint64_t a, uint64_t b)


### PR DESCRIPTION
Allows for difficulty state to be reset so it's not constantly attempting to find a higher difficulty than the last found hash.