### PR TITLE
Round based gpu mining

### DIFF
--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -67,12 +67,13 @@ __global__ void kernel_start_drill(
     uint64_t round)
 {
     // Drill and track best local nonce
+    uint64_t limit = 100000;
     uint64_t iters = 0;
-    uint64_t nonce = threadIdx.x + (blockIdx.x * blockDim.x); // TODO Initialize based on round
+    uint64_t nonce = threadIdx.x + (blockIdx.x * blockDim.x) + (round * stride * limit);
     uint64_t local_best_nonce = nonce;
     uint32_t local_best_difficulty = 0;
     uint8_t result[32];
-    while (iters < 1000000)
+    while (iters < limit)
     {
         kernel_drill_hash(d_challenge, &nonce, result);
         uint32_t hash_difficulty = difficulty(result);

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -24,7 +24,7 @@ extern "C" void get_noise(size_t *host_data)
     cudaMemcpyFromSymbol(host_data, noise, NOISE_SIZE_BYTES, 0, cudaMemcpyDeviceToHost);
 }
 
-extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t clockrate, uint64_t secs)
+extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
 {
     // Reset global state before starting the mining operation
     unsigned long long int zero = 0;
@@ -42,7 +42,7 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t clockrate,
     cudaMemcpy(d_challenge, challenge, 32, cudaMemcpyHostToDevice);
 
     // Calculate target cycle time. clockRate is in kHz
-    unsigned long long int target_cycles =  (unsigned long long)clockrate * (unsigned long long)(1000 * secs);
+    unsigned long long int target_cycles = clock_rate * (unsigned long long)(1000 * secs);
 
     // Launch the kernel to perform the hash operation
     uint64_t stride = number_blocks * number_threads;
@@ -93,17 +93,6 @@ __global__ void kernel_start_drill(
         nonce += stride;
         elapsed_cycles = clock64() - start_cycles;
     }
-
-    // Update best global nonce
-    // while (!atomicMax(&lock, 1))
-    // {
-    // }
-    // if (local_best_difficulty >= global_best_difficulty)
-    // {
-    //     global_best_difficulty = local_best_difficulty;
-    //     global_best_nonce = local_best_nonce;
-    // }
-    // atomicMin(&lock, 0);
 }
 
 extern "C" void single_drill_hash(uint8_t *challenge, uint64_t nonce, uint8_t *out)

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -6,7 +6,6 @@
 
 __device__ uint32_t global_best_difficulty = 0;
 __device__ unsigned long long int global_best_nonce = 0;
-__device__ unsigned long long int lock = 0;
 
 // Define the static array globally
 __device__ size_t noise[NOISE_SIZE_BYTES / USIZE_BYTE_SIZE];
@@ -24,15 +23,18 @@ extern "C" void get_noise(size_t *host_data)
     cudaMemcpyFromSymbol(host_data, noise, NOISE_SIZE_BYTES, 0, cudaMemcpyDeviceToHost);
 }
 
-extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
+extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, reset bool)
 {
     // Reset global state before starting the mining operation
-    unsigned long long int zero = 0;
-    uint32_t zero_difficulty = 0;
+    if (reset)
+    {
+        unsigned long long int zero = 0;
+        uint32_t zero_difficulty = 0;
 
-    // Use cudaMemcpyToSymbol if the variables are device symbols
-    cudaMemcpyToSymbol(global_best_nonce, &zero, sizeof(zero), 0, cudaMemcpyHostToDevice);
-    cudaMemcpyToSymbol(global_best_difficulty, &zero_difficulty, sizeof(zero_difficulty), 0, cudaMemcpyHostToDevice);
+        // Use cudaMemcpyToSymbol if the variables are device symbols
+        cudaMemcpyToSymbol(global_best_nonce, &zero, sizeof(zero), 0, cudaMemcpyHostToDevice);
+        cudaMemcpyToSymbol(global_best_difficulty, &zero_difficulty, sizeof(zero_difficulty), 0, cudaMemcpyHostToDevice);
+    }
 
     // Allocate device memory for input and output data
     uint8_t *d_challenge;
@@ -41,13 +43,9 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
     // Copy the host data to the device
     cudaMemcpy(d_challenge, challenge, 32, cudaMemcpyHostToDevice);
 
-    // Calculate target cycle time. clockRate is in kHz
-    unsigned long long int target_cycles = clock_rate * (unsigned long long)(1000 * secs);
-    printf("clockrate %lld target_cycles %lld", clock_rate, target_cycles);
-
     // Launch the kernel to perform the hash operation
     uint64_t stride = number_blocks * number_threads;
-    kernel_start_drill<<<number_blocks, number_threads>>>(d_challenge, stride, target_cycles);
+    kernel_start_drill<<<number_blocks, number_threads>>>(d_challenge, stride);
 
     // Retrieve the results back to the host
     cudaMemcpyFromSymbol(out, global_best_nonce, sizeof(global_best_nonce), 0, cudaMemcpyDeviceToHost);
@@ -65,17 +63,15 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
 
 __global__ void kernel_start_drill(
     uint8_t *d_challenge,
-    uint64_t stride,
-    unsigned long long int target_cycles)
+    uint64_t stride)
 {
     // Drill and track best local nonce
-    unsigned long long int start_cycles = clock64();
-    unsigned long long int elapsed_cycles = 0;
+    uint64_t iters = 0;
     uint64_t nonce = threadIdx.x + (blockIdx.x * blockDim.x);
     uint64_t local_best_nonce = nonce;
     uint32_t local_best_difficulty = 0;
     uint8_t result[32];
-    while (elapsed_cycles < target_cycles)
+    while (iters < 1000000)
     {
         kernel_drill_hash(d_challenge, &nonce, result);
         uint32_t hash_difficulty = difficulty(result);
@@ -92,7 +88,7 @@ __global__ void kernel_start_drill(
             }
         }
         nonce += stride;
-        elapsed_cycles = clock64() - start_cycles;
+        iters += 1;
     }
 }
 

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -92,7 +92,7 @@ __global__ void kernel_start_drill(
         }
         nonce += stride;
         iters += 1;
-        printf("iters %d limit %d", iters, limit);
+        printf("iters %llu limit %llu", iters, limit);
     }
 }
 

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -68,7 +68,7 @@ __global__ void kernel_start_drill(
     uint64_t round)
 {
     // Drill and track best local nonce
-    uint64_t limit = 100000;
+    uint64_t limit = 1000;
     uint64_t iters = 0;
     uint64_t nonce = threadIdx.x + (blockIdx.x * blockDim.x) + (round * stride * limit);
     uint64_t local_best_nonce = nonce;
@@ -92,10 +92,6 @@ __global__ void kernel_start_drill(
         }
         nonce += stride;
         iters += 1;
-        if (threadIdx.x == 0) 
-        {
-            printf("iters %llu limit %llu break %d", iters, limit, iters < limit);
-        }
     }
 }
 

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -92,7 +92,10 @@ __global__ void kernel_start_drill(
         }
         nonce += stride;
         iters += 1;
-        printf("iters %llu limit %llu", iters, limit);
+        if threadIdx.x == 0 
+        {
+            printf("iters %llu limit %llu break %d", iters, limit, iters < limit);
+        }
     }
 }
 

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -46,6 +46,7 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t round)
     // Launch the kernel to perform the hash operation
     uint64_t stride = number_blocks * number_threads;
     kernel_start_drill<<<number_blocks, number_threads>>>(d_challenge, stride, round);
+    cudaDeviceSynchronize();
 
     // Retrieve the results back to the host
     cudaMemcpyFromSymbol(out, global_best_nonce, sizeof(global_best_nonce), 0, cudaMemcpyDeviceToHost);

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -43,6 +43,7 @@ extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs)
 
     // Calculate target cycle time. clockRate is in kHz
     unsigned long long int target_cycles = clock_rate * (unsigned long long)(1000 * secs);
+    printf("clockrate %lld target_cycles %lld", clock_rate, target_cycles);
 
     // Launch the kernel to perform the hash operation
     uint64_t stride = number_blocks * number_threads;

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -92,6 +92,7 @@ __global__ void kernel_start_drill(
         }
         nonce += stride;
         iters += 1;
+        printf("iters %d limit %d", iters, limit);
     }
 }
 

--- a/drillx/kernels/orev2.cu
+++ b/drillx/kernels/orev2.cu
@@ -92,7 +92,7 @@ __global__ void kernel_start_drill(
         }
         nonce += stride;
         iters += 1;
-        if threadIdx.x == 0 
+        if (threadIdx.x == 0) 
         {
             printf("iters %llu limit %llu break %d", iters, limit, iters < limit);
         }

--- a/drillx/kernels/orev2.h
+++ b/drillx/kernels/orev2.h
@@ -14,8 +14,8 @@ extern "C" void set_noise(const uint64_t *data);
 extern "C" void get_noise(uint64_t *data);
 
 // host function that calls kernel_start_drill, a kernel that initializes the parallel routine that mines hashes for some time,
-extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs);
-__global__ void kernel_start_drill(uint8_t *d_challenge, uint64_t stride, unsigned long long int target_cycles);
+extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, bool secs);
+__global__ void kernel_start_drill(uint8_t *d_challenge, uint64_t stride);
 __device__ void mine(uint8_t *d_challenge, uint64_t nonce, uint32_t *local_best_difficulty, uint64_t *local_best_nonce);
 
 // host function that calls kernel_single_drill_hash, a non-parallel routine that does one hash

--- a/drillx/kernels/orev2.h
+++ b/drillx/kernels/orev2.h
@@ -14,7 +14,7 @@ extern "C" void set_noise(const uint64_t *data);
 extern "C" void get_noise(uint64_t *data);
 
 // host function that calls kernel_start_drill, a kernel that initializes the parallel routine that mines hashes for some time,
-extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t clockrate, uint64_t secs);
+extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t secs);
 __global__ void kernel_start_drill(uint8_t *d_challenge, uint64_t stride, unsigned long long int target_cycles);
 __device__ void mine(uint8_t *d_challenge, uint64_t nonce, uint32_t *local_best_difficulty, uint64_t *local_best_nonce);
 

--- a/drillx/kernels/orev2.h
+++ b/drillx/kernels/orev2.h
@@ -14,8 +14,8 @@ extern "C" void set_noise(const uint64_t *data);
 extern "C" void get_noise(uint64_t *data);
 
 // host function that calls kernel_start_drill, a kernel that initializes the parallel routine that mines hashes for some time,
-extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, bool secs);
-__global__ void kernel_start_drill(uint8_t *d_challenge, uint64_t stride);
+extern "C" void drill_hash(uint8_t *challenge, uint8_t *out, uint64_t round);
+__global__ void kernel_start_drill(uint8_t *d_challenge, uint64_t stride, uint64_t round);
 __device__ void mine(uint8_t *d_challenge, uint64_t nonce, uint32_t *local_best_difficulty, uint64_t *local_best_nonce);
 
 // host function that calls kernel_single_drill_hash, a non-parallel routine that does one hash

--- a/drillx/kernels/utils.cu
+++ b/drillx/kernels/utils.cu
@@ -6,7 +6,7 @@ int number_multi_processors;
 int number_blocks;
 int number_threads;
 int max_threads_per_mp;
-// unsigned long long int clock_rate;
+unsigned long long int clock_rate;
 
 // Greatest common denominator
 // Used in gpu_init() to calculate block_size
@@ -34,7 +34,7 @@ extern "C" void gpu_init()
     block_size = (max_threads_per_mp / gcd(max_threads_per_mp, number_threads));
     number_threads = 256; // / block_size;
     number_blocks = block_size * number_multi_processors;
-    // clock_rate = 1800000; // (unsigned long long)device_prop.clockRate;
+    clock_rate = (unsigned long long)device_prop.clockRate;
 }
 
 __device__ uint64_t saturating_add(uint64_t a, uint64_t b)

--- a/drillx/kernels/utils.cu
+++ b/drillx/kernels/utils.cu
@@ -6,7 +6,6 @@ int number_multi_processors;
 int number_blocks;
 int number_threads;
 int max_threads_per_mp;
-unsigned long long int clock_rate;
 
 // Greatest common denominator
 // Used in gpu_init() to calculate block_size
@@ -34,7 +33,6 @@ extern "C" void gpu_init()
     block_size = (max_threads_per_mp / gcd(max_threads_per_mp, number_threads));
     number_threads = 256; // / block_size;
     number_blocks = block_size * number_multi_processors;
-    clock_rate = (unsigned long long)device_prop.clockRate;
 }
 
 __device__ uint64_t saturating_add(uint64_t a, uint64_t b)

--- a/drillx/kernels/utils.h
+++ b/drillx/kernels/utils.h
@@ -5,7 +5,6 @@ extern int number_multi_processors;
 extern int number_blocks;
 extern int number_threads;
 extern int max_threads_per_mp;
-extern unsigned long long int clock_rate;
 
 // Initializes gpu parameters
 extern "C" void gpu_init();

--- a/drillx/kernels/utils.h
+++ b/drillx/kernels/utils.h
@@ -5,7 +5,7 @@ extern int number_multi_processors;
 extern int number_blocks;
 extern int number_threads;
 extern int max_threads_per_mp;
-// extern unsigned long long int clock_rate;
+extern unsigned long long int clock_rate;
 
 // Initializes gpu parameters
 extern "C" void gpu_init();

--- a/drillx/src/gpu.rs
+++ b/drillx/src/gpu.rs
@@ -1,5 +1,5 @@
 extern "C" {
-    pub fn drill_hash(challenge: *const u8, out: *mut u8, reset: bool);
+    pub fn drill_hash(challenge: *const u8, out: *mut u8, round: u64);
     pub fn single_drill_hash(challenge: *const u8, nonce: u64, out: *mut u8);
     pub fn set_noise(noise: *const usize);
     pub fn get_noise(noise: *const usize);

--- a/drillx/src/gpu.rs
+++ b/drillx/src/gpu.rs
@@ -1,5 +1,5 @@
 extern "C" {
-    pub fn drill_hash(challenge: *const u8, out: *mut u8, secs: u64);
+    pub fn drill_hash(challenge: *const u8, out: *mut u8, reset: bool);
     pub fn single_drill_hash(challenge: *const u8, nonce: u64, out: *mut u8);
     pub fn set_noise(noise: *const usize);
     pub fn get_noise(noise: *const usize);

--- a/drillx/src/gpu.rs
+++ b/drillx/src/gpu.rs
@@ -1,5 +1,5 @@
 extern "C" {
-    pub fn drill_hash(challenge: *const u8, out: *mut u8, clockrate: u64, secs: u64);
+    pub fn drill_hash(challenge: *const u8, out: *mut u8, secs: u64);
     pub fn single_drill_hash(challenge: *const u8, nonce: u64, out: *mut u8);
     pub fn set_noise(noise: *const usize);
     pub fn get_noise(noise: *const usize);

--- a/examples/example-3/src/main.rs
+++ b/examples/example-3/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let challenge = [255; 32];
     let mut nonce = [0; 8];
     unsafe {
-        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), 1800000, secs);
+        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), secs);
     }
     println!("{nonce:?}");
 

--- a/examples/example-3/src/main.rs
+++ b/examples/example-3/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let challenge = [255; 32];
     let mut nonce = [0; 8];
     unsafe {
-        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), true);
+        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), 0);
     }
     println!("{nonce:?}");
 

--- a/examples/example-3/src/main.rs
+++ b/examples/example-3/src/main.rs
@@ -15,11 +15,10 @@ fn main() {
 
     // Current challenge (255s for demo)
     let timer = Instant::now();
-    let secs = 5;
     let challenge = [255; 32];
     let mut nonce = [0; 8];
     unsafe {
-        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), secs);
+        drill_hash(challenge.as_ptr(), nonce.as_mut_ptr(), true);
     }
     println!("{nonce:?}");
 


### PR DESCRIPTION
Mine on gpu in hardcoded batches. This allows us to use the cpu timer to manage when to return and start submitting. More reliable than measuring clock cycles on the gpu