### PR TITLE
add benches to drillx with small improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake
+# vi: ft=sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.direnv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +146,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anyhow"
@@ -744,6 +756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +808,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,12 +866,31 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
+ "clap_lex 0.7.0",
 ]
 
 [[package]]
@@ -837,6 +901,12 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "combine"
@@ -937,6 +1007,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.4",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1217,7 +1323,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 name = "drillx"
 version = "0.1.0"
 dependencies = [
+ "blake3",
  "cc",
+ "criterion",
  "enum_dispatch",
  "equix",
  "num-traits",
@@ -1696,6 +1804,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2138,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2574,6 +2703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2893,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -5305,6 +5468,16 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "drillx",
     "examples/*",
@@ -21,3 +22,13 @@ solana-program-test = "1.18.11"
 solana-sdk = "1.18.11"
 strum = { version = "0.26.2", features = ["derive"] }
 tokio = { version = "1.37.0", features = ["full"] }
+
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
+[profile.bench]
+lto = "fat"
+codegen-units = 1

--- a/drillx/Cargo.toml
+++ b/drillx/Cargo.toml
@@ -15,17 +15,30 @@ keywords = ["solana", "crypto", "mining"]
 name = "drillx"
 
 [features]
-default = []
+default = ["full", "native"]
+program = ["dep:solana-program"]
+native = ["dep:blake3"]
 benchmark = []
+compiler = ["equix/compiler"]
+full = ["equix/full"]
 gpu = ["cc"]
 
 [dependencies]
 enum_dispatch = { workspace = true }
 num_enum = { workspace = true }
 num-traits = { workspace = true }
-solana-program = { workspace = true }
+solana-program = { workspace = true, optional = true }
 strum = { workspace = true }
 equix = "0.1.4"
+blake3 = { workspace = true, optional = true }
+
+[dev-dependencies]
+criterion = { workspace = true, default-features = true, features = ["html_reports"] }
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }
+
+
+[[bench]]
+name = "drillx_compiled"
+harness = false

--- a/drillx/benches/drillx_compiled.rs
+++ b/drillx/benches/drillx_compiled.rs
@@ -1,0 +1,28 @@
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main};
+
+fn drillx_compiled(nonces: u64) {
+    let mut memory = drillx::equix::SolverMemory::new();
+    let challenge = [255; 32];
+    for nonce in 0..nonces {
+        drillx::hash_with_shared_memory(&mut memory, &challenge, &nonce.to_le_bytes()).ok();
+    }
+}
+
+fn different_sizes(c: &mut Criterion) {
+    static KH: usize = 1000;
+
+    let mut group = c.benchmark_group("from_elem");
+    for size in [KH, 2 * KH, 4 * KH].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+            b.iter(|| drillx_compiled(size as u64))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, different_sizes);
+criterion_main!(benches);

--- a/drillx/src/lib.rs
+++ b/drillx/src/lib.rs
@@ -1,6 +1,25 @@
+/// Re-export the equix crate
+pub use equix;
+
 /// Generates a new drillx hash from a challenge and nonce
 pub fn hash(challenge: &[u8; 32], nonce: &[u8; 8]) -> Result<Hash, DrillxError> {
     let digest = build_digest(challenge, nonce)?;
+    Ok(Hash {
+        d: digest,
+        h: hashv(&digest, nonce),
+    })
+}
+
+/// Generates a new drillx hash from a challenge and nonce
+#[inline(always)]
+pub fn hash_with_shared_memory(
+    memory: &mut equix::SolverMemory,
+    challenge: &[u8; 32],
+    nonce: &[u8; 8],
+) -> Result<Hash, DrillxError> {
+    // Seed
+    let seed = construct_seed(challenge, nonce);
+    let digest = build_digest_with_shared_memory(memory, &seed)?;
     Ok(Hash {
         d: digest,
         h: hashv(&digest, nonce),
@@ -15,7 +34,22 @@ fn seed(challenge: &[u8; 32], nonce: &[u8; 8]) -> [u8; 40] {
     buf
 }
 
-/// Constructs a keccak digest from a challenge and nonce using equix hashes
+/// Concatenates two arrays into a single array
+#[inline(always)]
+fn construct_seed(a: &[u8; 32], b: &[u8; 8]) -> [u8; 40] {
+    let mut result = std::mem::MaybeUninit::uninit();
+    let dest = result.as_mut_ptr() as *mut u8;
+    // SAFETY: `dest` is valid for `40` elements.
+    // SAFETY: `a` and `b` are valid for `32` and `8` elements respectively.
+    // SAFETY: `a` and `b` are non-overlapping with `dest`.
+    unsafe {
+        core::ptr::copy_nonoverlapping(a.as_ptr(), dest, 32);
+        core::ptr::copy_nonoverlapping(b.as_ptr(), dest.add(32), 8);
+        result.assume_init()
+    }
+}
+
+/// Constructs a blake3 digest from a challenge and nonce using equix hashes
 fn build_digest(challenge: &[u8; 32], nonce: &[u8; 8]) -> Result<[u8; 16], DrillxError> {
     // Seed
     let seed = seed(challenge, nonce);
@@ -29,9 +63,27 @@ fn build_digest(challenge: &[u8; 32], nonce: &[u8; 8]) -> Result<[u8; 16], Drill
     };
 
     // Digest
-    let mut digest = [0u8; 16];
-    digest.copy_from_slice(solution.to_bytes().as_slice());
-    Ok(digest)
+    Ok(solution.to_bytes())
+}
+
+/// Constructs a blake3 digest from a challenge and nonce using equix hashes
+#[inline(always)]
+fn build_digest_with_shared_memory(
+    memory: &mut equix::SolverMemory,
+    seed: &[u8],
+) -> Result<[u8; 16], DrillxError> {
+    let equix = equix::EquiXBuilder::new()
+        .runtime(equix::RuntimeOption::CompileOnly)
+        .build(&seed)
+        .map_err(|_| DrillxError::BadEquix)?;
+
+    // Equix
+    let solutions = equix.solve_with_memory(memory);
+    // SAFETY: The equix solver guarantees that the first solution is always valid
+    let solution = unsafe { solutions.get_unchecked(0) };
+
+    // Digest
+    Ok(solution.to_bytes())
 }
 
 /// Returns true if the digest if valid equihash construction from the challenge and nonce
@@ -41,8 +93,19 @@ pub fn is_valid_digest(challenge: &[u8; 32], nonce: &[u8; 8], digest: &[u8; 16])
 }
 
 /// Calculates a hash from the provided digest and nonce
+#[cfg(all(feature = "program", not(feature = "native")))]
 fn hashv(digest: &[u8; 16], nonce: &[u8; 8]) -> [u8; 32] {
     solana_program::blake3::hashv(&[&digest.as_slice(), &nonce.as_slice()]).to_bytes()
+}
+
+/// Calculates a hash from the provided digest and nonce
+#[cfg(all(feature = "native", not(feature = "program")))]
+fn hashv(digest: &[u8; 16], nonce: &[u8; 8]) -> [u8; 32] {
+    // Hash an input incrementally.
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(digest);
+    hasher.update(nonce);
+    hasher.finalize().into()
 }
 
 /// Returns the number of leading zeros on a 32 byte buffer

--- a/examples/example-3/Cargo.toml
+++ b/examples/example-3/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 name = "example-3"
 
 [dependencies]
-drillx = { path = "../../drillx" }
+drillx = { path = "../../drillx", features = ["full"] }

--- a/examples/example-3/src/main.rs
+++ b/examples/example-3/src/main.rs
@@ -4,10 +4,11 @@ const TEST_SIZE: u64 = 1000;
 
 fn main() {
     println!("Benchmarking...");
+    let mut memory = drillx::equix::SolverMemory::new();
     let challenge = [255; 32];
     let timer = Instant::now();
     for nonce in 0..TEST_SIZE {
-        drillx::hash(&challenge, &nonce.to_le_bytes()).ok();
+        drillx::hash_with_shared_memory(&mut memory, &challenge, &nonce.to_le_bytes()).ok();
     }
     println!(
         "Did {} hashes in {} ms\nHashrate: {} H/s",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,85 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715413075,
+        "narHash": "sha256-FCi3R1MeS5bVp0M0xTheveP6hhcCYfW/aghSTPebYL4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4e7a43a9db7e22613accfeb1005cca1b2b1ee0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715393623,
+        "narHash": "sha256-nSUFcUqyTQQ/aYFIB05mpCzytcKvfKMy3ZQAe0fP26A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8eb8671512cb0c72c748058506e50c54fb5d8e2b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Drillix development environment";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    # Rust
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true;
+        };
+        lib = pkgs.lib;
+        toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      in
+      {
+        devShells.default = pkgs.mkShell
+          {
+            name = "ore-cli";
+            nativeBuildInputs = [
+              pkgs.pkg-config
+              pkgs.clang
+              # pkgs.zluda
+              # pkgs.cudaPackages.cuda_nvcc
+              # Mold Linker for faster builds (only on Linux)
+              (lib.optionals pkgs.stdenv.isLinux pkgs.mold)
+              (lib.optionals pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security)
+              (lib.optionals pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.SystemConfiguration)
+            ];
+            buildInputs = [
+              # We want the unwrapped version, wrapped comes with nixpkgs' toolchain
+              pkgs.rust-analyzer-unwrapped
+              # Finally the toolchain
+              toolchain
+            ];
+            packages = [
+              pkgs.solana-cli
+              pkgs.cargo-zigbuild
+            ];
+            # Environment variables
+            RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+            RUSTFLAGS = "-C target-cpu=native";
+          };
+      });
+}

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 
 [dependencies]
 bytemuck = { workspace = true }
-drillx = { path = "../drillx" }
+drillx = { path = "../drillx", default-features = false, features = ["program"] }
 solana-program = { workspace = true }
 
 [dev-dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "rust-analyzer", "rust-src" ]
+targets = ["x86_64-unknown-linux-musl"]
+profile = "minimal"
+


### PR DESCRIPTION
1. added Nix and flakes for local develop.
2. using nightly rust to get some extra optimizations
3. uses the native blake3 crate instead of the one on Solana-program when compiled using `native` feature
4. shares the memory between different equix invocation.
5. uses `-C target-cpu=native` RUSTCFLAGS when compiling locally.

Got from `175 H/s` to `189 H/s` that is about 8% increase.